### PR TITLE
fix: Update workflow to download spec files correctly

### DIFF
--- a/.github/workflows/spec-files-update.yml
+++ b/.github/workflows/spec-files-update.yml
@@ -12,12 +12,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download specification files
         run: |
-          curl https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/core/ad_types.yaml -o spec-files/ad_types.yaml \
-          && curl https://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/uuids/service_uuids.yaml -o spec-files/service_uuids.yaml
+          git clone --depth 1 https://bitbucket.org/bluetooth-SIG/public.git -b main bluetooth-sig
+          cp bluetooth-sig/assigned_numbers/core/ad_types.yaml spec-files/ad_types.yaml
+          cp bluetooth-sig/assigned_numbers/uuids/service_uuids.yaml spec-files/service_uuids.yaml
+          rm -rf bluetooth-sig
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chores: Update specification files."
           title: Automated updates to specification files
           body: This is an auto-generated PR with specification files updates.
+          author: Ghislain MARY <ghislain@ghislainmary.fr>
           branch: spec-files-updates
+          delete-branch: true


### PR DESCRIPTION
Refactor the GitHub Actions workflow to use git sparse checkout for downloading specification files from the Bluetooth SIG repository.
Additionally, update the author information for  the pull request.