### PR TITLE
refactor: Change HCI timeout parameter to Duration type

### DIFF
--- a/bletio-hci/src/hci.rs
+++ b/bletio-hci/src/hci.rs
@@ -1,4 +1,7 @@
-use core::num::{NonZeroU16, NonZeroU8};
+use core::{
+    num::{NonZeroU16, NonZeroU8},
+    time::Duration,
+};
 
 use crate::{
     AdvertisingData, AdvertisingEnable, AdvertisingParameters, Command, CommandCompleteEvent,
@@ -7,7 +10,7 @@ use crate::{
     SupportedLeFeatures, SupportedLeStates, TxPowerLevel, WithTimeout,
 };
 
-const HCI_COMMAND_TIMEOUT: u16 = 1000; // ms
+const HCI_COMMAND_TIMEOUT: Duration = Duration::from_millis(1000);
 
 #[derive(Debug)]
 pub struct Hci<H>

--- a/bletio-hci/src/timeout_embassy.rs
+++ b/bletio-hci/src/timeout_embassy.rs
@@ -1,13 +1,20 @@
 use core::future::Future;
+use core::time::Duration;
 
 use crate::{HciDriverError, WithTimeout};
 
 impl<F: Future> WithTimeout for F {
     type Output = F::Output;
 
-    async fn with_timeout(self, timeout_ms: u16) -> Result<Self::Output, HciDriverError> {
-        embassy_time::with_timeout(embassy_time::Duration::from_millis(timeout_ms as u64), self)
-            .await
-            .map_err(|_| HciDriverError::Timeout)
+    async fn with_timeout(
+        self,
+        timeout_duration: Duration,
+    ) -> Result<Self::Output, HciDriverError> {
+        embassy_time::with_timeout(
+            embassy_time::Duration::from_millis(timeout_duration.as_millis() as u64),
+            self,
+        )
+        .await
+        .map_err(|_| HciDriverError::Timeout)
     }
 }

--- a/bletio-hci/src/traits.rs
+++ b/bletio-hci/src/traits.rs
@@ -1,4 +1,5 @@
 use core::future::Future;
+use core::time::Duration;
 
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HciDriverError {
@@ -20,6 +21,6 @@ pub trait WithTimeout {
 
     fn with_timeout(
         self,
-        timeout: u16,
+        timeout_duration: Duration,
     ) -> impl Future<Output = Result<Self::Output, HciDriverError>>;
 }


### PR DESCRIPTION
Update the `with_timeout` method to accept a `Duration` type instead of a `u16` for timeout values. Adjust related tests and constants to use `Duration` consistently throughout the codebase.