### PR TITLE
refactor: Use const functions where possible

### DIFF
--- a/bletio-hci/src/advertising_parameters.rs
+++ b/bletio-hci/src/advertising_parameters.rs
@@ -27,16 +27,20 @@ pub struct AdvertisingIntervalValue {
 
 impl AdvertisingIntervalValue {
     /// Create a valid advertising interval value.
-    pub fn try_new(value: u16) -> Result<Self, Error> {
-        value.try_into()
+    pub const fn try_new(value: u16) -> Result<Self, Error> {
+        if (value >= 0x0020) && (value <= 0x4000) {
+            Ok(Self { value })
+        } else {
+            Err(Error::InvalidAdvertisingIntervalValue(value))
+        }
     }
 
     /// Get the value of the advertising interval value in milliseconds.
-    pub fn milliseconds(&self) -> f32 {
+    pub const fn milliseconds(&self) -> f32 {
         (self.value as f32) * 0.625
     }
 
-    pub fn value(&self) -> u16 {
+    pub const fn value(&self) -> u16 {
         self.value
     }
 }
@@ -51,11 +55,7 @@ impl TryFrom<u16> for AdvertisingIntervalValue {
     type Error = Error;
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        if (0x0020..=0x4000).contains(&value) {
-            Ok(Self { value })
-        } else {
-            Err(Error::InvalidAdvertisingIntervalValue(value))?
-        }
+        Self::try_new(value)
     }
 }
 

--- a/bletio-hci/src/command.rs
+++ b/bletio-hci/src/command.rs
@@ -112,7 +112,7 @@ impl Command {
         })
     }
 
-    pub(crate) fn opcode(&self) -> CommandOpCode {
+    pub(crate) const fn opcode(&self) -> CommandOpCode {
         match self {
             // Self::LeClearFilterAcceptList => CommandOpCode::LeClearFilterAcceptList,
             Self::LeRand => CommandOpCode::LeRand,

--- a/bletio-hci/src/connection_interval.rs
+++ b/bletio-hci/src/connection_interval.rs
@@ -14,19 +14,25 @@ pub struct ConnectionInterval {
 
 impl ConnectionInterval {
     /// Create a connection interval value with a defined value.
-    pub fn try_new(value: u16) -> Result<Self, Error> {
-        value.try_into()
+    pub const fn try_new(value: u16) -> Result<Self, Error> {
+        if (value >= 0x0006) && (value <= 0x0C80) {
+            Ok(Self {
+                value: ConnectionIntervalType::Defined(value),
+            })
+        } else {
+            Err(Error::InvalidConnectionIntervalValue(value))
+        }
     }
 
     /// Create an undefined connection interval value.
-    pub fn undefined() -> Self {
+    pub const fn undefined() -> Self {
         Self {
             value: ConnectionIntervalType::Undefined,
         }
     }
 
     /// Get the value of the connection interval value in milliseconds.
-    pub fn milliseconds(&self) -> Option<f32> {
+    pub const fn milliseconds(&self) -> Option<f32> {
         match self.value {
             ConnectionIntervalType::Defined(value) => Some(value as f32 * 1.25),
             ConnectionIntervalType::Undefined => None,
@@ -44,13 +50,7 @@ impl TryFrom<u16> for ConnectionInterval {
     type Error = Error;
 
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        if (0x0006..=0x0C80).contains(&value) {
-            Ok(Self {
-                value: ConnectionIntervalType::Defined(value),
-            })
-        } else {
-            Err(Error::InvalidConnectionIntervalValue(value))
-        }
+        Self::try_new(value)
     }
 }
 

--- a/bletio-hci/src/error_code.rs
+++ b/bletio-hci/src/error_code.rs
@@ -188,7 +188,7 @@ pub enum ErrorCode {
 }
 
 impl ErrorCode {
-    pub fn is_success(&self) -> bool {
+    pub const fn is_success(&self) -> bool {
         matches!(self, Self::Success)
     }
 }

--- a/bletio-hci/src/packet.rs
+++ b/bletio-hci/src/packet.rs
@@ -23,7 +23,6 @@ pub(crate) enum PacketType {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Packet {
-    #[allow(dead_code)]
     Command(Command),
     Event(Event),
 }

--- a/bletio-hci/src/tx_power_level.rs
+++ b/bletio-hci/src/tx_power_level.rs
@@ -9,11 +9,15 @@ pub struct TxPowerLevel {
 }
 
 impl TxPowerLevel {
-    pub fn try_new(value: i8) -> Result<Self, Error> {
-        value.try_into()
+    pub const fn try_new(value: i8) -> Result<Self, Error> {
+        if value > 20 {
+            Err(Error::InvalidTxPowerLevelValue(value))
+        } else {
+            Ok(Self { value })
+        }
     }
 
-    pub fn value(&self) -> i8 {
+    pub const fn value(&self) -> i8 {
         self.value
     }
 }
@@ -22,11 +26,7 @@ impl TryFrom<i8> for TxPowerLevel {
     type Error = Error;
 
     fn try_from(value: i8) -> Result<Self, Error> {
-        if value > 20 {
-            Err(Error::InvalidTxPowerLevelValue(value))
-        } else {
-            Ok(Self { value })
-        }
+        Self::try_new(value)
     }
 }
 

--- a/bletio-host/src/advertising/ad_struct/advertising_interval.rs
+++ b/bletio-host/src/advertising/ad_struct/advertising_interval.rs
@@ -17,7 +17,7 @@ pub(crate) struct AdvertisingIntervalAdStruct {
 }
 
 impl AdvertisingIntervalAdStruct {
-    pub(crate) fn new(interval: AdvertisingIntervalValue) -> Self {
+    pub(crate) const fn new(interval: AdvertisingIntervalValue) -> Self {
         Self { interval }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/appearance.rs
+++ b/bletio-host/src/advertising/ad_struct/appearance.rs
@@ -16,7 +16,7 @@ pub struct AppearanceAdStruct {
 }
 
 impl AppearanceAdStruct {
-    pub(crate) fn new(appearance: AppearanceValue) -> Self {
+    pub(crate) const fn new(appearance: AppearanceValue) -> Self {
         Self { appearance }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/flags.rs
+++ b/bletio-host/src/advertising/ad_struct/flags.rs
@@ -18,7 +18,7 @@ pub(crate) struct FlagsAdStruct {
 }
 
 impl FlagsAdStruct {
-    pub(crate) fn new(flags: Flags) -> Self {
+    pub(crate) const fn new(flags: Flags) -> Self {
         Self { flags }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/le_supported_features.rs
+++ b/bletio-host/src/advertising/ad_struct/le_supported_features.rs
@@ -16,7 +16,7 @@ pub(crate) struct LeSupportedFeaturesAdStruct {
 }
 
 impl LeSupportedFeaturesAdStruct {
-    pub(crate) fn new(features: SupportedLeFeatures) -> Self {
+    pub(crate) const fn new(features: SupportedLeFeatures) -> Self {
         Self { features }
     }
 

--- a/bletio-host/src/advertising/ad_struct/local_name.rs
+++ b/bletio-host/src/advertising/ad_struct/local_name.rs
@@ -22,14 +22,14 @@ pub struct LocalNameAdStruct<'a> {
 }
 
 impl<'a> LocalNameAdStruct<'a> {
-    pub(crate) fn new(local_name: &'a str, complete: LocalNameComplete) -> Self {
+    pub(crate) const fn new(local_name: &'a str, complete: LocalNameComplete) -> Self {
         Self {
             local_name,
             complete,
         }
     }
 
-    fn len(&self) -> usize {
+    const fn len(&self) -> usize {
         match self.complete {
             LocalNameComplete::Complete => self.local_name.len(),
             LocalNameComplete::Shortened(len) => {

--- a/bletio-host/src/advertising/ad_struct/manufacturer_specific_data.rs
+++ b/bletio-host/src/advertising/ad_struct/manufacturer_specific_data.rs
@@ -17,7 +17,7 @@ pub(crate) struct ManufacturerSpecificDataAdStruct<'a> {
 }
 
 impl<'a> ManufacturerSpecificDataAdStruct<'a> {
-    pub(crate) fn new(manufacturer: CompanyIdentifier, data: &'a [u8]) -> Self {
+    pub(crate) const fn new(manufacturer: CompanyIdentifier, data: &'a [u8]) -> Self {
         Self { manufacturer, data }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/peripheral_connection_interval_range.rs
+++ b/bletio-host/src/advertising/ad_struct/peripheral_connection_interval_range.rs
@@ -17,7 +17,7 @@ pub(crate) struct PeripheralConnectionIntervalRangeAdStruct {
 }
 
 impl PeripheralConnectionIntervalRangeAdStruct {
-    pub(crate) fn new(range: RangeInclusive<ConnectionInterval>) -> Self {
+    pub(crate) const fn new(range: RangeInclusive<ConnectionInterval>) -> Self {
         Self { range }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/public_target_address.rs
+++ b/bletio-host/src/advertising/ad_struct/public_target_address.rs
@@ -17,7 +17,9 @@ pub(crate) struct PublicTargetAddressAdStruct<'a> {
 }
 
 impl<'a> PublicTargetAddressAdStruct<'a> {
-    pub(crate) fn try_new(addresses: &'a [PublicDeviceAddress]) -> Result<Self, AdvertisingError> {
+    pub(crate) const fn try_new(
+        addresses: &'a [PublicDeviceAddress],
+    ) -> Result<Self, AdvertisingError> {
         if addresses.is_empty() {
             Err(AdvertisingError::PublicTargetAddressAdStructMustContainAtLeastOneAddress)
         } else {

--- a/bletio-host/src/advertising/ad_struct/random_target_address.rs
+++ b/bletio-host/src/advertising/ad_struct/random_target_address.rs
@@ -18,7 +18,7 @@ pub(crate) struct RandomTargetAddressAdStruct<'a> {
 
 impl<'a> RandomTargetAddressAdStruct<'a> {
     // TODO: Limit to random static and random resolvable addresses
-    pub(crate) fn try_new(addresses: &'a [RandomAddress]) -> Result<Self, AdvertisingError> {
+    pub(crate) const fn try_new(addresses: &'a [RandomAddress]) -> Result<Self, AdvertisingError> {
         if addresses.is_empty() {
             Err(AdvertisingError::RandomTargetAddressAdStructMustContainAtLeastOneAddress)
         } else {

--- a/bletio-host/src/advertising/ad_struct/service_data.rs
+++ b/bletio-host/src/advertising/ad_struct/service_data.rs
@@ -13,7 +13,7 @@ pub(crate) struct ServiceDataUuid16AdStruct<'a> {
 }
 
 impl<'a> ServiceDataUuid16AdStruct<'a> {
-    pub(crate) fn new(uuid: ServiceUuid, data: &'a [u8]) -> Self {
+    pub(crate) const fn new(uuid: ServiceUuid, data: &'a [u8]) -> Self {
         Self { uuid, data }
     }
 }
@@ -45,7 +45,7 @@ pub(crate) struct ServiceDataUuid32AdStruct<'a> {
 }
 
 impl<'a> ServiceDataUuid32AdStruct<'a> {
-    pub(crate) fn new(uuid: Uuid32, data: &'a [u8]) -> Self {
+    pub(crate) const fn new(uuid: Uuid32, data: &'a [u8]) -> Self {
         Self { uuid, data }
     }
 }
@@ -77,7 +77,7 @@ pub(crate) struct ServiceDataUuid128AdStruct<'a> {
 }
 
 impl<'a> ServiceDataUuid128AdStruct<'a> {
-    pub(crate) fn new(uuid: Uuid128, data: &'a [u8]) -> Self {
+    pub(crate) const fn new(uuid: Uuid128, data: &'a [u8]) -> Self {
         Self { uuid, data }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/service_solicitation.rs
+++ b/bletio-host/src/advertising/ad_struct/service_solicitation.rs
@@ -17,7 +17,7 @@ pub(crate) struct ServiceSolicitationUuid16AdStruct<'a> {
 }
 
 impl<'a> ServiceSolicitationUuid16AdStruct<'a> {
-    pub(crate) fn new(uuids: &'a [ServiceUuid]) -> Self {
+    pub(crate) const fn new(uuids: &'a [ServiceUuid]) -> Self {
         Self { uuids }
     }
 }
@@ -54,7 +54,7 @@ pub(crate) struct ServiceSolicitationUuid32AdStruct<'a> {
 }
 
 impl<'a> ServiceSolicitationUuid32AdStruct<'a> {
-    pub(crate) fn new(uuids: &'a [Uuid32]) -> Self {
+    pub(crate) const fn new(uuids: &'a [Uuid32]) -> Self {
         Self { uuids }
     }
 }
@@ -91,7 +91,7 @@ pub(crate) struct ServiceSolicitationUuid128AdStruct<'a> {
 }
 
 impl<'a> ServiceSolicitationUuid128AdStruct<'a> {
-    pub(crate) fn new(uuids: &'a [Uuid128]) -> Self {
+    pub(crate) const fn new(uuids: &'a [Uuid128]) -> Self {
         Self { uuids }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/tx_power_level.rs
+++ b/bletio-host/src/advertising/ad_struct/tx_power_level.rs
@@ -17,7 +17,7 @@ pub(crate) struct TxPowerLevelAdStruct {
 }
 
 impl TxPowerLevelAdStruct {
-    pub(crate) fn new(tx_power_level: TxPowerLevel) -> Self {
+    pub(crate) const fn new(tx_power_level: TxPowerLevel) -> Self {
         Self { tx_power_level }
     }
 }

--- a/bletio-host/src/advertising/ad_struct/uri.rs
+++ b/bletio-host/src/advertising/ad_struct/uri.rs
@@ -12,7 +12,7 @@ pub(crate) struct UriAdStruct {
 }
 
 impl UriAdStruct {
-    pub(crate) fn new(uri: Uri) -> Self {
+    pub(crate) const fn new(uri: Uri) -> Self {
         Self { uri }
     }
 }

--- a/bletio-host/src/advertising/uri.rs
+++ b/bletio-host/src/advertising/uri.rs
@@ -224,7 +224,7 @@ pub enum UriScheme {
 }
 
 impl UriScheme {
-    fn value(&self) -> u16 {
+    const fn value(&self) -> u16 {
         match self {
             Self::Provisioned(scheme) => *scheme as u16,
             Self::Custom(_) => EMPTY_SCHEME_NAME_VALUE,

--- a/bletio-utils/src/lib.rs
+++ b/bletio-utils/src/lib.rs
@@ -12,7 +12,7 @@ pub enum Error {
     BufferTooSmall,
 }
 
-pub(crate) fn encode_le_u128(buffer: &mut [u8], data: u128) -> Result<usize, Error> {
+pub(crate) const fn encode_le_u128(buffer: &mut [u8], data: u128) -> Result<usize, Error> {
     if buffer.len() < 16 {
         Err(Error::BufferTooSmall)
     } else {
@@ -36,7 +36,7 @@ pub(crate) fn encode_le_u128(buffer: &mut [u8], data: u128) -> Result<usize, Err
     }
 }
 
-pub(crate) fn encode_le_u64(buffer: &mut [u8], data: u64) -> Result<usize, Error> {
+pub(crate) const fn encode_le_u64(buffer: &mut [u8], data: u64) -> Result<usize, Error> {
     if buffer.len() < 8 {
         Err(Error::BufferTooSmall)
     } else {
@@ -52,7 +52,7 @@ pub(crate) fn encode_le_u64(buffer: &mut [u8], data: u64) -> Result<usize, Error
     }
 }
 
-pub(crate) fn encode_le_u32(buffer: &mut [u8], data: u32) -> Result<usize, Error> {
+pub(crate) const fn encode_le_u32(buffer: &mut [u8], data: u32) -> Result<usize, Error> {
     if buffer.len() < 4 {
         Err(Error::BufferTooSmall)
     } else {
@@ -64,7 +64,7 @@ pub(crate) fn encode_le_u32(buffer: &mut [u8], data: u32) -> Result<usize, Error
     }
 }
 
-pub(crate) fn encode_le_u16(buffer: &mut [u8], data: u16) -> Result<usize, Error> {
+pub(crate) const fn encode_le_u16(buffer: &mut [u8], data: u16) -> Result<usize, Error> {
     if buffer.len() < 2 {
         Err(Error::BufferTooSmall)
     } else {


### PR DESCRIPTION
Update several functions to `const fn` to enable compile-time evaluations and optimizations.