### PR TITLE
feat: Add defmt formatting support and remove thiserror dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["embedded", "no-std"]
 approx = "0.5"
 bitflags = "2.8"
 claims = "0.8"
+defmt = "0.3"
 embassy-time = { version = "0.4" }
 nom = { version = "8.0", default-features = false }
 num_enum = { version = "0.7", default-features = false }
 rstest = "0.24"
-thiserror = { version = "2.0", default-features = false }
 tokio = { version = "1.43", features = ["rt", "time"] }
 tokio-macros = "2.5"
 tokio-test = "0.4"

--- a/bletio-hci/Cargo.toml
+++ b/bletio-hci/Cargo.toml
@@ -12,14 +12,15 @@ categories.workspace = true
 default = ["tokio"]
 embassy = ["dep:embassy-time"]
 tokio = ["dep:tokio"]
+defmt = ["dep:defmt", "bletio-utils/defmt"]
 
 [dependencies]
 bitflags = { workspace = true }
 bletio-utils = { path = "../bletio-utils" }
+defmt = { workspace = true, optional = true }
 embassy-time = { workspace = true, optional = true }
 nom = { workspace = true }
 num_enum = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/bletio-hci/src/advertising_data.rs
+++ b/bletio-hci/src/advertising_data.rs
@@ -13,6 +13,7 @@ const ADVERTISING_DATA_DATA_OFFSET: usize = 1;
 /// The packet format for the Advertising Data is defined in
 /// [Core Specification 6.0, Vol.3, Part C, 11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/generic-access-profile.html#UUID-51247611-bdce-274e-095c-afb6d879c55c).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingData {
     buffer: Buffer<ADVERTISING_DATA_TOTAL_SIZE>,
 }
@@ -77,6 +78,7 @@ impl bletio_utils::EncodeToBuffer for AdvertisingData {
 /// The packet format for the Scan Response Data is defined in
 /// [Core Specification 6.0, Vol.3, Part C, 11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/generic-access-profile.html#UUID-51247611-bdce-274e-095c-afb6d879c55c).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanResponseData {
     buffer: Buffer<ADVERTISING_DATA_TOTAL_SIZE>,
 }

--- a/bletio-hci/src/advertising_enable.rs
+++ b/bletio-hci/src/advertising_enable.rs
@@ -7,6 +7,7 @@ use crate::Error;
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.9](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-e58c6816-c25e-367a-0023-9da1700a3794).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidAdvertisingEnableValue))]
 #[repr(u8)]
 #[non_exhaustive]

--- a/bletio-hci/src/advertising_parameters.rs
+++ b/bletio-hci/src/advertising_parameters.rs
@@ -2,7 +2,11 @@
 //!
 //! These Advertising Parameters need to be defined to start advertising.
 
+#[cfg(not(feature = "defmt"))]
 use bitflags::bitflags;
+#[cfg(feature = "defmt")]
+use defmt::bitflags;
+
 use bletio_utils::{BufferOps, EncodeToBuffer, Error as UtilsError};
 use core::ops::RangeInclusive;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -21,6 +25,7 @@ use crate::{DeviceAddress, Error, OwnAddressType};
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingInterval {
     value: u16,
 }
@@ -75,6 +80,7 @@ impl EncodeToBuffer for AdvertisingInterval {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingIntervalRange {
     value: RangeInclusive<AdvertisingInterval>,
 }
@@ -204,6 +210,7 @@ pub use __advertising_interval_range__ as advertising_interval_range;
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidAdvertisingType))]
 #[repr(u8)]
 #[non_exhaustive]
@@ -265,16 +272,14 @@ impl EncodeToBuffer for PeerAddressType {
     }
 }
 
-/// Channel map of the channels to use for advertising.
-///
-/// Defaults to all the 3 channels (37, 38 & 39).
-///
-/// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct AdvertisingChannelMap(u8);
-
 bitflags! {
-    impl AdvertisingChannelMap: u8 {
+    /// Channel map of the channels to use for advertising.
+    ///
+    /// Defaults to all the 3 channels (37, 38 & 39).
+    ///
+    /// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Clone, Copy, PartialEq, Eq))]
+    pub struct AdvertisingChannelMap: u8 {
         /// Channel 37 shall be used.
         const CHANNEL37 = 1 << 0;
         /// Channel 38 shall be used.
@@ -310,6 +315,7 @@ impl EncodeToBuffer for AdvertisingChannelMap {
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidAdvertisingFilterPolicy))]
 #[repr(u8)]
 #[non_exhaustive]
@@ -348,6 +354,7 @@ impl EncodeToBuffer for AdvertisingFilterPolicy {
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingParameters {
     interval: AdvertisingIntervalRange,
     r#type: AdvertisingType,
@@ -488,7 +495,7 @@ pub(crate) mod parser {
     }
 
     fn channel_map(input: &[u8]) -> IResult<&[u8], AdvertisingChannelMap> {
-        map(le_u8(), AdvertisingChannelMap::from_bits_retain).parse(input)
+        map(le_u8(), AdvertisingChannelMap::from_bits_truncate).parse(input)
     }
 
     fn filter_policy(input: &[u8]) -> IResult<&[u8], AdvertisingFilterPolicy> {

--- a/bletio-hci/src/command.rs
+++ b/bletio-hci/src/command.rs
@@ -17,6 +17,7 @@ const fn opcode(ogf: u16, ocf: u16) -> u16 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, FromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 pub(crate) enum CommandOpCode {
     Nop = opcode(NOP_OGF, 0x0000),
@@ -49,6 +50,7 @@ pub(crate) enum CommandOpCode {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum Command {
     // LeAddDeviceToFilterAcceptList(AddressType, Address),
     // LeClearFilterAcceptList,
@@ -165,6 +167,7 @@ const HCI_COMMAND_PACKET_LENGTH_OFFSET: usize = 3;
 const HCI_COMMAND_PACKET_DATA_OFFSET: usize = 4;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct CommandPacket {
     buffer: Buffer<HCI_COMMAND_MAX_SIZE>,
 }

--- a/bletio-hci/src/connection_interval.rs
+++ b/bletio-hci/src/connection_interval.rs
@@ -8,6 +8,7 @@ use crate::Error;
 ///  - Time = N × 1.25 ms
 ///  - Time Range: 7.5 ms to 4 s
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ConnectionInterval {
     value: ConnectionIntervalType,
 }
@@ -64,6 +65,7 @@ impl From<ConnectionInterval> for u16 {
 }
 
 #[derive(Debug, Copy, Clone, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum ConnectionIntervalType {
     Defined(u16),
     Undefined,

--- a/bletio-hci/src/device_address.rs
+++ b/bletio-hci/src/device_address.rs
@@ -15,6 +15,7 @@ use crate::Error;
 ///
 /// See [Core Specification 6.0, Vol.6, Part B, 1.3](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/low-energy-controller/link-layer-specification.html#UUID-a0f4480f-c97e-c6bc-58ad-6e05d3b7d3a9).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DeviceAddress {
     Public(PublicDeviceAddress),
     Random(RandomAddress),
@@ -85,6 +86,7 @@ impl EncodeToBuffer for DeviceAddress {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct AddressBase {
     value: [u8; 6],
 }
@@ -96,6 +98,7 @@ impl From<[u8; 6]> for AddressBase {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PublicDeviceAddress {
     base: AddressBase,
 }
@@ -143,6 +146,7 @@ impl EncodeToBuffer for PublicDeviceAddress {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RandomAddress {
     Static(RandomStaticDeviceAddress),
     ResolvablePrivate(RandomResolvablePrivateAddress),
@@ -226,6 +230,7 @@ impl EncodeToBuffer for RandomAddress {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RandomStaticDeviceAddress {
     base: AddressBase,
 }
@@ -305,6 +310,7 @@ impl TryFrom<[u8; 6]> for RandomStaticDeviceAddress {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RandomResolvablePrivateAddress {
     base: AddressBase,
 }
@@ -379,6 +385,7 @@ impl EncodeToBuffer for RandomResolvablePrivateAddress {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RandomNonResolvablePrivateAddress {
     base: AddressBase,
 }

--- a/bletio-hci/src/error.rs
+++ b/bletio-hci/src/error.rs
@@ -1,99 +1,72 @@
 use crate::{ErrorCode, HciDriverError};
 
 /// Error occuring in the HCI part of the BLE stack.
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// At least one channel must be enabled in the advertising channel map.
-    #[error("At least one channel must be enabled in the advertising channel map")]
     AtLeastOneChannelMustBeEnabledInTheAdvertisingChannelMap,
     /// The provided data is too big to fit in an HCI command packet.
-    #[error("The provided data is too big to fit in an HCI command packet")]
     DataWillNotFitCommandPacket,
     /// HCI error code.
-    #[error("HCI error code {0:?}")]
     ErrorCode(ErrorCode),
-    #[error(transparent)]
-    HciDriver(#[from] HciDriverError),
+    HciDriver(HciDriverError),
     /// The provided advertising enable value is invalid.
-    #[error("The advertising enable value {0} is invalid")]
     InvalidAdvertisingEnableValue(u8),
     /// The provided advertising filter policy is invalid.
-    #[error("The advertising filter policy {0} is invalid")]
     InvalidAdvertisingFilterPolicy(u8),
     /// The provided advertising interval value is invalid, it needs to be between 0x0020 and 0x4000.
-    #[error(
-        "The advertising interval value {0} is invalid, it needs to be between 0x0020 and 0x4000"
-    )]
     InvalidAdvertisingInterval(u16),
     /// The advertising interval range is invalid, the first value must be smaller or equal to the second one.
-    #[error("The advertising interval range is invalid, the first value must be smaller or equal to the second one")]
     InvalidAdvertisingIntervalRange,
     /// The provided advertising type is invalid.
-    #[error("The advertising type {0} is invalid")]
     InvalidAdvertisingType(u8),
     /// Invalid HCI command.
-    #[error("Invalid HCI command with opcode {0}")]
     InvalidCommand(u16),
     /// The provided connection interval value is invalid, it needs to be between 0x0006 and 0x0C80.
-    #[error(
-        "The connection interval value {0} is invalid, it needs to be between 0x0006 and 0x0C80"
-    )]
     InvalidConnectionIntervalValue(u16),
     /// Invalid or unhandled HCI error code.
-    #[error("Invalid HCI error code {0}")]
     InvalidErrorCode(u8),
     /// Invalid HCI event packet.
-    #[error("Invalid HCI event packet")]
     InvalidEventPacket,
     /// The provided filter duplicates value is invalid.
-    #[error("The filter duplicates value {0} is invalid")]
     InvalidFilterDuplicatesValue(u8),
     /// The provided own address type is invalid.
-    #[error("The own address type {0} is invalid")]
     InvalidOwnAddressType(u8),
     /// Invalid HCI packet, either malformed or not expected (eg. Command received by the Host).
-    #[error("Invalid HCI packet")]
     InvalidPacket,
     /// Invalid or unhandled HCI packet type.
-    #[error("Invalid HCI packet type {0}")]
     InvalidPacketType(u8),
     /// The provided peer address type is invalid.
-    #[error("The peer address type {0} is invalid")]
     InvalidPeerAddressType(u8),
     /// The provided public device address is invalid.
-    #[error("The public device address is invalid.")]
     InvalidPublicDeviceAddress,
     /// The provided random address is invalid.
-    #[error("The random address is invalid.")]
     InvalidRandomAddress,
     /// The provided random non-resolvable private address is invalid.
-    #[error("The random non-resolvable private address is invalid.")]
     InvalidRandomNonResolvablePrivateAddress,
     /// The provided random resolvable private address is invalid.
-    #[error("The random resolvable private address is invalid.")]
     InvalidRandomResolvablePrivateAddress,
     /// The provided random static device address is invalid.
-    #[error("The random static device address is invalid")]
     InvalidRandomStaticDeviceAddress,
     /// The provided scan enable value is invalid.
-    #[error("The scan enable value {0} is invalid")]
     InvalidScanEnableValue(u8),
     /// The provided scan interval is invalid, it needs to be between 0x0004 and 0x4000.
-    #[error("The scan interval {0} is invalid, it needs to be between 0x0004 and 0x4000")]
     InvalidScanInterval(u16),
     /// The provided scan type is invalid.
-    #[error("The scan type {0} is invalid")]
     InvalidScanType(u8),
     /// The provided scan window is invalid, it needs to be between 0x0004 and 0x4000.
-    #[error("The scan window {0} is invalid, it needs to be between 0x0004 and 0x4000")]
     InvalidScanWindow(u16),
     /// The provided scanning filter policy is invalid.
-    #[error("The scanning filter policy {0} is invalid")]
     InvalidScanningFilterPolicy(u8),
     /// The provided TX power level value is invalid.
-    #[error("The TX power level value {0} is invalid")]
     InvalidTxPowerLevelValue(i8),
     /// The scan window must be smaller or equal to the scan interval.
-    #[error("The scan window must be smaller or equal to the scan interval")]
     ScanWindowMustBeSmallerOrEqualToScanInterval,
+}
+
+impl From<HciDriverError> for Error {
+    fn from(value: HciDriverError) -> Self {
+        Self::HciDriver(value)
+    }
 }

--- a/bletio-hci/src/error_code.rs
+++ b/bletio-hci/src/error_code.rs
@@ -5,6 +5,7 @@ use crate::Error;
 /// HCI error codes as defined in
 /// [Core Specification 6.0, Vol.1, Part F](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/architecture,-change-history,-and-conventions/controller-error-codes.html).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidErrorCode))]
 #[repr(u8)]
 #[non_exhaustive]

--- a/bletio-hci/src/event.rs
+++ b/bletio-hci/src/event.rs
@@ -6,12 +6,14 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum Event {
     CommandComplete(CommandCompleteEvent),
     Unsupported(u8),
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub(crate) enum EventCode {
     CommandComplete = 0x0E,
@@ -28,6 +30,7 @@ impl From<u8> for EventCode {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct CommandCompleteEvent {
     pub(crate) num_hci_command_packets: u8,
     pub(crate) opcode: CommandOpCode,
@@ -49,6 +52,7 @@ impl CommandCompleteEvent {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum EventParameter {
     Empty,
     Status(StatusEventParameter),
@@ -64,6 +68,7 @@ pub(crate) enum EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusEventParameter {
     pub(crate) status: ErrorCode,
 }
@@ -75,6 +80,7 @@ impl From<StatusEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndBdAddrEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) bd_addr: PublicDeviceAddress,
@@ -87,6 +93,7 @@ impl From<StatusAndBdAddrEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndBufferSizeEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) acl_data_packet_length: NonZeroU16,
@@ -102,6 +109,7 @@ impl From<StatusAndBufferSizeEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndLeBufferSizeEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) le_acl_data_packet_length: u16,
@@ -115,6 +123,7 @@ impl From<StatusAndLeBufferSizeEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndRandomNumberEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) random_number: [u8; 8],
@@ -127,6 +136,7 @@ impl From<StatusAndRandomNumberEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndSupportedCommandsEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) supported_commands: SupportedCommands,
@@ -139,6 +149,7 @@ impl From<StatusAndSupportedCommandsEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndSupportedFeaturesEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) supported_features: SupportedFeatures,
@@ -151,6 +162,7 @@ impl From<StatusAndSupportedFeaturesEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndSupportedLeFeaturesEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) supported_le_features: SupportedLeFeatures,
@@ -163,6 +175,7 @@ impl From<StatusAndSupportedLeFeaturesEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndSupportedLeStatesEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) supported_le_states: SupportedLeStates,
@@ -175,6 +188,7 @@ impl From<StatusAndSupportedLeStatesEventParameter> for EventParameter {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct StatusAndTxPowerLevelEventParameter {
     pub(crate) status: ErrorCode,
     pub(crate) tx_power_level: TxPowerLevel,
@@ -229,7 +243,7 @@ pub(crate) mod parser {
     }
 
     fn supported_features(input: &[u8]) -> IResult<&[u8], SupportedFeatures> {
-        map(le_u64(), SupportedFeatures::from_bits_retain).parse(input)
+        map(le_u64(), SupportedFeatures::from_bits_truncate).parse(input)
     }
 
     fn bd_addr(input: &[u8]) -> IResult<&[u8], PublicDeviceAddress> {

--- a/bletio-hci/src/hci_buffer.rs
+++ b/bletio-hci/src/hci_buffer.rs
@@ -5,6 +5,7 @@ use crate::{HciDriver, HciDriverError};
 const HCI_MAX_READ_BUFFER_SIZE: usize = 259;
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct HciBuffer {
     buffer: Buffer<HCI_MAX_READ_BUFFER_SIZE>,
 }

--- a/bletio-hci/src/le_event_mask.rs
+++ b/bletio-hci/src/le_event_mask.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "defmt"))]
 use bitflags::bitflags;
+#[cfg(feature = "defmt")]
+use defmt::bitflags;
+
 use bletio_utils::EncodeToBuffer;
 
 bitflags! {
@@ -6,7 +10,7 @@ bitflags! {
     ///
     /// The values are defined in
     /// [Core Specification 6.0, Vol. 4, Part E, 7.8.1](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-cefc532c-3752-3f40-b5c1-91070b4dfef8).
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Clone, Copy, PartialEq, Eq))]
     pub struct LeEventMask: u64 {
         /// Indicates to both of the Hosts forming the connection that a new connection has been created.
         const LE_CONNECTION_COMPLETE = 1 << 0;
@@ -102,7 +106,7 @@ bitflags! {
         /// Indicates to both of the Hosts forming the connection that a new connection has been created.
         const LE_ENHANCED_CONNECTION_COMPLETE_V2 = 1 << 40;
         /// Indicates that a CIS has been established, was considered lost before being established, or (on the Central) was rejected by the Peripheral.
-        const LE_CIS_ESTABLISHED_v2 = 1 << 41;
+        const LE_CIS_ESTABLISHED_V2 = 1 << 41;
         /// Indicates the completion of the process of the Controller obtaining the features supported by a remote Bluetooth device.
         const LE_READ_ALL_REMOTE_FEATURES_COMPLETE = 1 << 42;
         /// Generated when a locally initiated CS Capabilities Exchange procedure has completed or when the local Controller
@@ -150,7 +154,7 @@ impl EncodeToBuffer for LeEventMask {
 
 impl Default for LeEventMask {
     fn default() -> Self {
-        Self::from_bits_retain(0x0000_0000_0000_001F)
+        Self::from_bits_truncate(0x0000_0000_0000_001F)
     }
 }
 
@@ -164,7 +168,7 @@ pub(crate) mod parser {
     use super::*;
 
     pub(crate) fn le_event_mask(input: &[u8]) -> IResult<&[u8], LeEventMask> {
-        all_consuming(map(le_u64(), LeEventMask::from_bits_retain)).parse(input)
+        all_consuming(map(le_u64(), LeEventMask::from_bits_truncate)).parse(input)
     }
 }
 

--- a/bletio-hci/src/le_states.rs
+++ b/bletio-hci/src/le_states.rs
@@ -1,6 +1,7 @@
 use core::cmp::Ordering;
 
 #[derive(Debug, Clone, Copy, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LeState {
     Single(LeSingleState),
     Combined(LeCombinedState),
@@ -46,6 +47,7 @@ impl From<LeCombinedState> for LeState {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LeSingleState {
     ScannableAdvertising,
     ConnectableAdvertising,
@@ -60,6 +62,7 @@ pub enum LeSingleState {
 }
 
 #[derive(Debug, Clone, Copy, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LeCombinedState(pub LeSingleState, pub LeSingleState);
 
 impl PartialEq for LeCombinedState {

--- a/bletio-hci/src/lib.rs
+++ b/bletio-hci/src/lib.rs
@@ -5,7 +5,6 @@ pub mod scan_parameters;
 
 mod advertising_data;
 mod advertising_enable;
-mod buffer;
 mod command;
 mod connection_interval;
 mod device_address;
@@ -14,6 +13,7 @@ mod error_code;
 mod event;
 mod event_mask;
 mod hci;
+mod hci_buffer;
 mod le_event_mask;
 mod le_states;
 mod own_address_type;
@@ -34,7 +34,6 @@ mod timeout_embassy;
 #[cfg(feature = "tokio")]
 mod timeout_tokio;
 
-pub(crate) use buffer::HciBuffer;
 pub(crate) use command::{Command, CommandOpCode};
 pub(crate) use event::{
     CommandCompleteEvent, Event, EventCode, EventParameter, StatusAndBdAddrEventParameter,
@@ -44,6 +43,7 @@ pub(crate) use event::{
     StatusAndSupportedLeStatesEventParameter, StatusAndTxPowerLevelEventParameter,
     StatusEventParameter,
 };
+pub(crate) use hci_buffer::HciBuffer;
 pub(crate) use packet::{Packet, PacketType};
 
 pub use advertising_data::{AdvertisingData, ScanResponseData};

--- a/bletio-hci/src/own_address_type.rs
+++ b/bletio-hci/src/own_address_type.rs
@@ -7,6 +7,7 @@ use crate::Error;
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.5](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-3142c154-1bdd-37b2-cc6e-006aa755f5f7).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidOwnAddressType))]
 #[repr(u8)]
 #[non_exhaustive]

--- a/bletio-hci/src/packet.rs
+++ b/bletio-hci/src/packet.rs
@@ -10,6 +10,7 @@ use crate::{Command, Error, Event};
 ///
 /// See [Core Specification 6.0, Vol. 4, Part A, 2](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/uart-transport-layer.html#UUID-361053ee-862f-c591-00bd-1a941a12f949).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidPacketType))]
 #[repr(u8)]
 #[non_exhaustive]
@@ -22,6 +23,7 @@ pub(crate) enum PacketType {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum Packet {
     Command(Command),
     Event(Event),

--- a/bletio-hci/src/scan_enable.rs
+++ b/bletio-hci/src/scan_enable.rs
@@ -7,6 +7,7 @@ use crate::Error;
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-bf0262b2-c9d0-b457-8405-5cf531a0bff1).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidScanEnableValue))]
 #[repr(u8)]
 #[non_exhaustive]
@@ -32,6 +33,7 @@ impl EncodeToBuffer for ScanEnable {
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-bf0262b2-c9d0-b457-8405-5cf531a0bff1).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidFilterDuplicatesValue))]
 #[repr(u8)]
 #[non_exhaustive]

--- a/bletio-hci/src/scan_parameters.rs
+++ b/bletio-hci/src/scan_parameters.rs
@@ -11,6 +11,7 @@ use crate::{Error, OwnAddressType};
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-fff6f93e-315b-04fe-51bf-a18f78ceec89).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidScanType))]
 #[repr(u8)]
 #[non_exhaustive]
@@ -44,6 +45,7 @@ impl EncodeToBuffer for ScanType {
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-fff6f93e-315b-04fe-51bf-a18f78ceec89).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanInterval {
     value: u16,
 }
@@ -164,6 +166,7 @@ pub use __scan_interval__ as scan_interval;
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-fff6f93e-315b-04fe-51bf-a18f78ceec89).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanWindow {
     value: u16,
 }
@@ -276,6 +279,7 @@ pub use __scan_window__ as scan_window;
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-fff6f93e-315b-04fe-51bf-a18f78ceec89).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[num_enum(error_type(name = Error, constructor = Error::InvalidScanningFilterPolicy))]
 #[repr(u8)]
 #[non_exhaustive]
@@ -312,6 +316,7 @@ impl EncodeToBuffer for ScanningFilterPolicy {
 ///
 /// See [Core Specification 6.0, Vol.4, Part E, 7.8.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-fff6f93e-315b-04fe-51bf-a18f78ceec89).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanParameters {
     r#type: ScanType,
     interval: ScanInterval,

--- a/bletio-hci/src/supported_commands.rs
+++ b/bletio-hci/src/supported_commands.rs
@@ -7,6 +7,7 @@ bitflags_array! {
     /// These commands are defined in
     /// [Core Specification 6.0, Vol. 4, Part E, 6.27](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host-controller-interface/host-controller-interface-functional-specification.html#UUID-d5f3af07-8495-3fe6-8afe-c6e6db371233).
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct SupportedCommands: 64 {
         const READ_BUFFER_SIZE = (14, 7);
         const READ_BD_ADDR = (15, 1);

--- a/bletio-hci/src/supported_features.rs
+++ b/bletio-hci/src/supported_features.rs
@@ -1,11 +1,15 @@
+#[cfg(not(feature = "defmt"))]
 use bitflags::bitflags;
+#[cfg(feature = "defmt")]
+use defmt::bitflags;
 
 bitflags! {
     /// Features supported by the Link Manager.
     ///
     /// These features are defined in
     /// [Core Specification 6.0, Vol. 2, Part C, 3](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/br-edr-controller/link-manager-protocol-specification.html#UUID-248645a8-42ca-a871-78ce-4487981382d8).
-    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Default, Clone, Copy, PartialEq, Eq))]
+    #[cfg_attr(feature = "defmt", derive(Default))]
     pub struct SupportedFeatures: u64 {
         /// This feature indicates whether the Controller supports LE.
         /// The local Host uses this feature bit to determine whether the Controller supports LE.

--- a/bletio-hci/src/supported_le_features.rs
+++ b/bletio-hci/src/supported_le_features.rs
@@ -7,6 +7,7 @@ bitflags_array! {
     /// These features are defined in
     /// [Core Specification 6.0, Vol. 6, Part B, 4.6](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/low-energy-controller/link-layer-specification.html#UUID-25d414b5-8c50-cd46-fd17-80f0f816f354).
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct SupportedLeFeatures: 9 {
         /// The controller supports encryption on all the logical transports and:
         ///  - LL_ENC_REQ

--- a/bletio-hci/src/supported_le_states.rs
+++ b/bletio-hci/src/supported_le_states.rs
@@ -1,6 +1,7 @@
 use crate::{LeCombinedState, LeSingleState, LeState};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SupportedLeStates {
     value: u64,
 }

--- a/bletio-hci/src/traits.rs
+++ b/bletio-hci/src/traits.rs
@@ -1,13 +1,11 @@
 use core::future::Future;
 use core::time::Duration;
 
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum HciDriverError {
-    #[error("HCI driver write failure")]
     WriteFailure,
-    #[error("HCI driver read failure")]
     ReadFailure,
-    #[error("HCI driver timeout")]
     Timeout,
 }
 

--- a/bletio-hci/src/tx_power_level.rs
+++ b/bletio-hci/src/tx_power_level.rs
@@ -4,6 +4,7 @@ use crate::Error;
 ///
 /// The value ranges from -127 to 20 dBm.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TxPowerLevel {
     value: i8,
 }

--- a/bletio-host/Cargo.toml
+++ b/bletio-host/Cargo.toml
@@ -12,12 +12,13 @@ categories.workspace = true
 default = ["tokio"]
 embassy = ["bletio-hci/embassy"]
 tokio = ["bletio-hci/tokio"]
+defmt = ["dep:defmt", "bletio-hci/defmt", "bletio-utils/defmt"]
 
 [dependencies]
 bitflags = { workspace = true }
 bletio-hci = { path = "../bletio-hci", default-features = false }
 bletio-utils = { path = "../bletio-utils" }
-thiserror = { workspace = true }
+defmt = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/bletio-host/src/advertising/ad_struct/advertising_interval.rs
+++ b/bletio-host/src/advertising/ad_struct/advertising_interval.rs
@@ -12,6 +12,7 @@ const ADVERTISING_INTERVAL_AD_STRUCT_SIZE: usize = 3;
 /// and
 /// [Core Specification 6.0, Vol. 6, Part B, 4.4.2.2](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/low-energy-controller/link-layer-specification.html#UUID-f6cd1541-800c-c516-b32b-95dd0479840b).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct AdvertisingIntervalAdStruct {
     interval: AdvertisingInterval,
 }

--- a/bletio-host/src/advertising/ad_struct/appearance.rs
+++ b/bletio-host/src/advertising/ad_struct/appearance.rs
@@ -11,6 +11,7 @@ const APPEARANCE_AD_STRUCT_SIZE: usize = 3;
 /// and
 /// [Core Specification 6.0, Vol. 3, Part C, 12.2](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/generic-access-profile.html#UUID-ec0b9e4b-8d14-7280-a0ae-68c61f6f00eb).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AppearanceAdStruct {
     appearance: AppearanceValue,
 }

--- a/bletio-host/src/advertising/ad_struct/flags.rs
+++ b/bletio-host/src/advertising/ad_struct/flags.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "defmt"))]
 use bitflags::bitflags;
+#[cfg(feature = "defmt")]
+use defmt::bitflags;
+
 use bletio_utils::EncodeToBuffer;
 
 use crate::assigned_numbers::AdType;
@@ -13,6 +17,7 @@ const FLAGS_AD_STRUCT_SIZE: usize = 2;
 ///
 /// See [`Flags`] for more information about each of the flags.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct FlagsAdStruct {
     flags: Flags,
 }
@@ -39,14 +44,12 @@ impl EncodeToBuffer for FlagsAdStruct {
     }
 }
 
-/// Flags to be used in a [FlagsAdStruct](crate::advertising::ad_struct::FlagsAdStruct)
-/// Advertising Structure, as defined in
-/// [Supplement to the Bluetooth Core Specification, Part A, 1.3](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-801bc3e0-519d-2291-8acd-d32d1fd27a4e).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Flags(u8);
-
 bitflags! {
-    impl Flags: u8 {
+    /// Flags to be used in a [FlagsAdStruct](crate::advertising::ad_struct::FlagsAdStruct)
+    /// Advertising Structure, as defined in
+    /// [Supplement to the Bluetooth Core Specification, Part A, 1.3](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-801bc3e0-519d-2291-8acd-d32d1fd27a4e).
+    #[cfg_attr(not(feature = "defmt"), derive(Debug, Clone, Copy, PartialEq, Eq))]
+    pub struct Flags: u8 {
         /// Low-Energy Limited Discoverable Mode.
         const LE_LIMITED_DISCOVERABLE_MODE = 1 << 0;
         /// Low-Energy General Discoverable Mode.

--- a/bletio-host/src/advertising/ad_struct/le_supported_features.rs
+++ b/bletio-host/src/advertising/ad_struct/le_supported_features.rs
@@ -11,6 +11,7 @@ use crate::assigned_numbers::AdType;
 /// and
 /// [Core Specification 6.0, Vol. 6, Part B, 4.6](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/low-energy-controller/link-layer-specification.html#UUID-25d414b5-8c50-cd46-fd17-80f0f816f354).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct LeSupportedFeaturesAdStruct {
     features: SupportedLeFeatures,
 }

--- a/bletio-host/src/advertising/ad_struct/local_name.rs
+++ b/bletio-host/src/advertising/ad_struct/local_name.rs
@@ -6,6 +6,7 @@ use crate::assigned_numbers::AdType;
 ///
 /// Used when creating a Local Name Advertising Structures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LocalNameComplete {
     Complete,
     Shortened(usize),
@@ -16,6 +17,7 @@ pub enum LocalNameComplete {
 /// The local name of the device is defined in
 /// [Supplement to the Bluetooth Core Specification, Part A, 1.2](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-351cc997-6a3c-8980-31cb-21b2ffcb103f).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LocalNameAdStruct<'a> {
     local_name: &'a str,
     pub(crate) complete: LocalNameComplete,

--- a/bletio-host/src/advertising/ad_struct/manufacturer_specific_data.rs
+++ b/bletio-host/src/advertising/ad_struct/manufacturer_specific_data.rs
@@ -11,6 +11,7 @@ use crate::assigned_numbers::CompanyIdentifier;
 ///
 /// This is used for example for iBeacons and Eddystone beacons.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ManufacturerSpecificDataAdStruct<'a> {
     manufacturer: CompanyIdentifier,
     data: &'a [u8],

--- a/bletio-host/src/advertising/ad_struct/peripheral_connection_interval_range.rs
+++ b/bletio-host/src/advertising/ad_struct/peripheral_connection_interval_range.rs
@@ -12,6 +12,7 @@ const PERIPHERAL_CONNECTION_INTERVAL_RANGE_AD_STRUCT_SIZE: usize = 5;
 /// For more information about this connection interval, see
 /// [Core Specification 6.0, Vol.3, Part C, 12.3](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/generic-access-profile.html#UUID-7ef0bdcb-4c81-1aea-5f65-4a69eab5c899).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct PeripheralConnectionIntervalRangeAdStruct {
     range: RangeInclusive<ConnectionInterval>,
 }

--- a/bletio-host/src/advertising/ad_struct/public_target_address.rs
+++ b/bletio-host/src/advertising/ad_struct/public_target_address.rs
@@ -12,6 +12,7 @@ use crate::{advertising::AdvertisingError, assigned_numbers::AdType};
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.13](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-d42b32b3-1877-b82c-fd79-5d755328de9f).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct PublicTargetAddressAdStruct<'a> {
     addresses: &'a [PublicDeviceAddress],
 }

--- a/bletio-host/src/advertising/ad_struct/random_target_address.rs
+++ b/bletio-host/src/advertising/ad_struct/random_target_address.rs
@@ -12,6 +12,7 @@ use crate::{advertising::AdvertisingError, assigned_numbers::AdType};
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.14](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-9c825fe7-7092-a219-ecb4-2294c2c12d9a).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct RandomTargetAddressAdStruct<'a> {
     addresses: &'a [RandomAddress],
 }

--- a/bletio-host/src/advertising/ad_struct/service_data.rs
+++ b/bletio-host/src/advertising/ad_struct/service_data.rs
@@ -7,6 +7,7 @@ use crate::uuid::{Uuid128, Uuid32};
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-dea15cd4-bc0f-91f0-82c1-3bbe596f7bf6).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceDataUuid16AdStruct<'a> {
     uuid: ServiceUuid,
     data: &'a [u8],
@@ -39,6 +40,7 @@ impl EncodeToBuffer for ServiceDataUuid16AdStruct<'_> {
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-dea15cd4-bc0f-91f0-82c1-3bbe596f7bf6).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceDataUuid32AdStruct<'a> {
     uuid: Uuid32,
     data: &'a [u8],
@@ -71,6 +73,7 @@ impl EncodeToBuffer for ServiceDataUuid32AdStruct<'_> {
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.11](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-dea15cd4-bc0f-91f0-82c1-3bbe596f7bf6).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceDataUuid128AdStruct<'a> {
     uuid: Uuid128,
     data: &'a [u8],

--- a/bletio-host/src/advertising/ad_struct/service_solicitation.rs
+++ b/bletio-host/src/advertising/ad_struct/service_solicitation.rs
@@ -12,6 +12,7 @@ use crate::uuid::{Uuid128, Uuid32};
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-302574d9-585b-209a-c32f-c5b6278f3377).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceSolicitationUuid16AdStruct<'a> {
     uuids: &'a [ServiceUuid],
 }
@@ -49,6 +50,7 @@ impl EncodeToBuffer for ServiceSolicitationUuid16AdStruct<'_> {
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-302574d9-585b-209a-c32f-c5b6278f3377).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceSolicitationUuid32AdStruct<'a> {
     uuids: &'a [Uuid32],
 }
@@ -86,6 +88,7 @@ impl EncodeToBuffer for ServiceSolicitationUuid32AdStruct<'_> {
 ///
 /// See [Supplement to the Bluetooth Core Specification, Part A, 1.10](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-302574d9-585b-209a-c32f-c5b6278f3377).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceSolicitationUuid128AdStruct<'a> {
     uuids: &'a [Uuid128],
 }

--- a/bletio-host/src/advertising/ad_struct/service_uuid.rs
+++ b/bletio-host/src/advertising/ad_struct/service_uuid.rs
@@ -18,6 +18,7 @@ pub enum ServiceListComplete {
 /// This list can be complete or incomplete. If the list is empty, it shall be marked as complete,
 /// as defined in [Supplement to the Bluetooth Core Specification, Part A, 1.1](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-b1d0edbc-fc9e-507a-efe4-3fd4b4817a52).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceUuid16AdStruct<'a> {
     uuids: &'a [ServiceUuid],
     ad_type: AdType,
@@ -68,6 +69,7 @@ impl EncodeToBuffer for ServiceUuid16AdStruct<'_> {
 /// This list can be complete or incomplete. If the list is empty, it shall be marked as complete,
 /// as defined in [Supplement to the Bluetooth Core Specification, Part A, 1.1](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-b1d0edbc-fc9e-507a-efe4-3fd4b4817a52).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceUuid32AdStruct<'a> {
     uuids: &'a [Uuid32],
     ad_type: AdType,
@@ -118,6 +120,7 @@ impl EncodeToBuffer for ServiceUuid32AdStruct<'_> {
 /// This list can be complete or incomplete. If the list is empty, it shall be marked as complete,
 /// as defined in [Supplement to the Bluetooth Core Specification, Part A, 1.1](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-b1d0edbc-fc9e-507a-efe4-3fd4b4817a52).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct ServiceUuid128AdStruct<'a> {
     uuids: &'a [Uuid128],
     ad_type: AdType,

--- a/bletio-host/src/advertising/ad_struct/tx_power_level.rs
+++ b/bletio-host/src/advertising/ad_struct/tx_power_level.rs
@@ -12,6 +12,7 @@ const TX_POWER_LEVEL_AD_STRUCT_SIZE: usize = 2;
 ///
 /// Note: When the TX Power Level Adevertising Structure is not present, the TX power level of the packet is unknown.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct TxPowerLevelAdStruct {
     tx_power_level: TxPowerLevel,
 }

--- a/bletio-host/src/advertising/ad_struct/uri.rs
+++ b/bletio-host/src/advertising/ad_struct/uri.rs
@@ -7,6 +7,7 @@ use crate::{advertising::Uri, assigned_numbers::AdType};
 /// The URI is encoded as defined in
 /// [Supplement to the Bluetooth Core Specification, Part A, 1.18](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/CSS_v12/CSS/out/en/supplement-to-the-bluetooth-core-specification/data-types-specification.html#UUID-64bd7c4c-daf3-7a73-143a-b3dba8faac95).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct UriAdStruct {
     uri: Uri,
 }

--- a/bletio-host/src/advertising/advertising_data.rs
+++ b/bletio-host/src/advertising/advertising_data.rs
@@ -20,6 +20,7 @@ use crate::uuid::{Uuid128, Uuid32};
 use crate::{DeviceInformation, Error};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FullAdvertisingData<'a> {
     pub(crate) adv_data: AdvertisingData<'a>,
     pub(crate) scanresp_data: Option<ScanResponseData<'a>>,
@@ -314,6 +315,7 @@ impl<'a> AdvertisingDataBuilder<'a> {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingDataBase<'a> {
     advertising_interval: Option<AdvertisingIntervalAdStruct>,
     appearance: Option<AppearanceAdStruct>,
@@ -494,6 +496,7 @@ impl EncodeToBuffer for AdvertisingDataBase<'_> {
 ///
 /// Use the [`AdvertisingDataBuilder`] to instantiate it.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingData<'a> {
     base: AdvertisingDataBase<'a>,
     flags: Option<FlagsAdStruct>,
@@ -797,6 +800,7 @@ impl<'a> ScanResponseDataBuilder<'a> {
 ///
 /// Use the [`ScanResponseDataBuilder`] to instantiate it.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanResponseData<'a> {
     base: AdvertisingDataBase<'a>,
 }

--- a/bletio-host/src/advertising/advertising_parameters.rs
+++ b/bletio-host/src/advertising/advertising_parameters.rs
@@ -91,6 +91,7 @@ impl AdvertisingParametersBuilder {
 ///
 /// Use the [`AdvertisingParametersBuilder`] to instantiate it.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisingParameters {
     inner: bletio_hci::AdvertisingParameters,
 }

--- a/bletio-host/src/advertising/mod.rs
+++ b/bletio-host/src/advertising/mod.rs
@@ -28,27 +28,21 @@ pub use scan_parameters::{ScanParameters, ScanParametersBuilder};
 pub use uri::{custom_uri_scheme, CustomUriScheme, Uri, UriScheme};
 
 /// Error occuring in the advertising part of the BLE stack.
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AdvertisingError {
     /// The provided advertising data is too big to fit in an advertising data or scan response data packet.
-    #[error("The provided advertising data is too big to fit in an advertising data or scan response data packet")]
     AdvertisingDataWillNotFitAdvertisingPacket,
     /// The Appearance Advertising Structure is not allowed to be present in both the Advertising Data and the Scan Response Data.
-    #[error("The Appearance Advertising Structure is not allowed to be present in both the Advertising Data and the Scan Response Data")]
     AppearanceNotAllowedInBothAdvertisingDataAndScanResponseData,
     /// An empty service UUID list Advertising Structure needs to be complete.
-    #[error("An empty service UUID list Advertising Structure needs to be complete")]
     EmptyServiceUuidListShallBeComplete,
     /// The Public Target Address Advertising Structure must contain at least one address.
-    #[error("The Public Target Address Advertising Structure must contain at least one address")]
     PublicTargetAddressAdStructMustContainAtLeastOneAddress,
     /// The Random Target Address Advertising Structure must contain at least one address.
-    #[error("The Random Target Address Advertising Structure must contain at least one address")]
     RandomTargetAddressAdStructMustContainAtLeastOneAddress,
     /// The advertising parameters are not valid, probably because the advertising type is ScannableUndirected or NonConnectableUndirected, and the minimum advertising interval value is less than 0x00A0.
-    #[error("The advertising parameters are not valid, probably because the advertising type is ScannableUndirected or NonConnectableUndirected, and the minimum advertising interval value is less than 0x00A0")]
     InvalidAdvertisingParameters,
     /// The scan parameters are not valid, probably because the scan window is larger than the scan interval.
-    #[error("The scan parameters are not valid, probably because the scan window is larger than the scan interval")]
     InvalidScanParameters,
 }

--- a/bletio-host/src/advertising/scan_parameters.rs
+++ b/bletio-host/src/advertising/scan_parameters.rs
@@ -77,6 +77,7 @@ impl ScanParametersBuilder {
 ///
 /// Use the [`ScanParametersBuilder`] to instantiate it.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ScanParameters {
     inner: bletio_hci::ScanParameters,
 }

--- a/bletio-host/src/advertising/uri.rs
+++ b/bletio-host/src/advertising/uri.rs
@@ -6,6 +6,7 @@ const EMPTY_SCHEME_NAME_VALUE: u16 = 0x0001;
 
 /// An URI to be included in the Universal Resource Identifier Advertising Structure.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Uri {
     scheme: UriScheme,
     hier_part: &'static str,
@@ -155,6 +156,7 @@ pub const fn check_custom_uri_scheme_has_alphanumeric_last_char(scheme: &str) ->
 ///
 /// Use [`custom_uri_scheme`] to create it.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CustomUriScheme {
     scheme: &'static str,
 }
@@ -216,6 +218,7 @@ pub use __custom_uri_scheme__ as custom_uri_scheme;
 
 /// An URI scheme, either provisioned or custom.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum UriScheme {
     /// A provisioned URI scheme.
     Provisioned(ProvisionedUriScheme),

--- a/bletio-host/src/assigned_numbers/ad_types.rs
+++ b/bletio-host/src/assigned_numbers/ad_types.rs
@@ -3,6 +3,7 @@
 //! FILE GENERATED FROM REVISION efc887857333456bda4ac2762443a7a86c99a27b OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 #[allow(dead_code)]
 #[non_exhaustive]

--- a/bletio-host/src/assigned_numbers/appearance_values.rs
+++ b/bletio-host/src/assigned_numbers/appearance_values.rs
@@ -3,6 +3,7 @@
 //! FILE GENERATED FROM REVISION efc887857333456bda4ac2762443a7a86c99a27b OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[allow(dead_code)]
 #[non_exhaustive]

--- a/bletio-host/src/assigned_numbers/company_identifiers.rs
+++ b/bletio-host/src/assigned_numbers/company_identifiers.rs
@@ -3,6 +3,7 @@
 //! FILE GENERATED FROM REVISION efc887857333456bda4ac2762443a7a86c99a27b OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[non_exhaustive]
 /// Assigned numbers for company identifiers defined in

--- a/bletio-host/src/assigned_numbers/service_uuids.rs
+++ b/bletio-host/src/assigned_numbers/service_uuids.rs
@@ -3,6 +3,7 @@
 //! FILE GENERATED FROM REVISION efc887857333456bda4ac2762443a7a86c99a27b OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[non_exhaustive]
 /// Assigned numbers for Bluetooth GATT services defined in

--- a/bletio-host/src/assigned_numbers/uri_schemes.rs
+++ b/bletio-host/src/assigned_numbers/uri_schemes.rs
@@ -3,6 +3,7 @@
 //! FILE GENERATED FROM REVISION efc887857333456bda4ac2762443a7a86c99a27b OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[non_exhaustive]
 /// Assigned numbers for Bluetooth URI schemes defined in

--- a/bletio-host/src/device_information.rs
+++ b/bletio-host/src/device_information.rs
@@ -9,6 +9,7 @@ use bletio_hci::{
 use crate::assigned_numbers::AppearanceValue;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct DeviceInformation<'a> {
     pub(crate) appearance: AppearanceValue,
     pub(crate) le_data_packet_length: NonZeroU16,

--- a/bletio-host/src/lib.rs
+++ b/bletio-host/src/lib.rs
@@ -22,20 +22,29 @@ pub(crate) use device_information::DeviceInformation;
 use advertising::AdvertisingError;
 
 /// Errors that can happen during the BLE stack usage.
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Advertising related error.
-    #[error(transparent)]
-    Advertising(#[from] AdvertisingError),
+    Advertising(AdvertisingError),
     /// HCI related error.
-    #[error(transparent)]
-    Hci(#[from] HciError),
+    Hci(HciError),
     /// The Bluetooth controller is not LE capable.
-    #[error("The Bluetooth controller is not LE capable")]
     NonLeCapableController,
     /// The Random Static Device Address has already been created.
-    #[error("The Random Static Device Address has already been created")]
     RandomAddressAlreadyCreated,
+}
+
+impl From<AdvertisingError> for Error {
+    fn from(value: AdvertisingError) -> Self {
+        Self::Advertising(value)
+    }
+}
+
+impl From<HciError> for Error {
+    fn from(value: HciError) -> Self {
+        Self::Hci(value)
+    }
 }
 
 impl From<HciDriverError> for Error {

--- a/bletio-host/src/uuid.rs
+++ b/bletio-host/src/uuid.rs
@@ -2,6 +2,7 @@
 const BLUETOOTH_BASE_UUID: u128 = 0x00000000_0000_1000_8000_00805F9B34FB;
 
 #[derive(Debug, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Uuid {
     Uuid16(Uuid16),
     Uuid32(Uuid32),
@@ -25,6 +26,7 @@ impl PartialEq for Uuid {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Uuid16(pub u16);
 
 impl From<u16> for Uuid16 {
@@ -46,6 +48,7 @@ impl PartialEq<Uuid128> for Uuid16 {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Uuid32(pub u32);
 
 impl From<u32> for Uuid32 {
@@ -73,6 +76,7 @@ impl PartialEq<Uuid128> for Uuid32 {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Uuid128(pub u128);
 
 impl From<u128> for Uuid128 {

--- a/bletio-utils/Cargo.toml
+++ b/bletio-utils/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = []
+defmt = ["dep:defmt"]
+
 [dependencies]
 bitflags = { workspace = true }
-thiserror = { workspace = true }
+defmt = { workspace = true, optional = true }

--- a/bletio-utils/src/bit_flags_array.rs
+++ b/bletio-utils/src/bit_flags_array.rs
@@ -3,6 +3,7 @@ use core::ops::{BitAnd, BitOr, BitXor, Not};
 use bitflags::Bits;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BitFlagsArray<const CAP: usize>(pub [u8; CAP]);
 
 impl<const CAP: usize> BitFlagsArray<CAP> {

--- a/bletio-utils/src/buffer.rs
+++ b/bletio-utils/src/buffer.rs
@@ -24,6 +24,7 @@ pub trait EncodeToBuffer {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Buffer<const CAP: usize> {
     pub data: [u8; CAP],
     pub offset: usize,

--- a/bletio-utils/src/lib.rs
+++ b/bletio-utils/src/lib.rs
@@ -6,9 +6,8 @@ mod buffer;
 pub use bit_flags_array::BitFlagsArray;
 pub use buffer::{Buffer, BufferOps, EncodeToBuffer};
 
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
-    #[error("Buffer too small")]
     BufferTooSmall,
 }
 

--- a/update-assigned-numbers/src/main.rs
+++ b/update-assigned-numbers/src/main.rs
@@ -114,6 +114,7 @@ fn generate_ad_types(
 //! FILE GENERATED FROM REVISION {} OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 #[allow(dead_code)]
 #[non_exhaustive]
@@ -258,6 +259,7 @@ fn generate_appearance_values(
 //! FILE GENERATED FROM REVISION {} OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[allow(dead_code)]
 #[non_exhaustive]
@@ -373,6 +375,7 @@ fn generate_company_identifiers(
 //! FILE GENERATED FROM REVISION {} OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[non_exhaustive]
 /// Assigned numbers for company identifiers defined in
@@ -443,6 +446,7 @@ fn generate_service_uuids(
 //! FILE GENERATED FROM REVISION {} OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[non_exhaustive]
 /// Assigned numbers for Bluetooth GATT services defined in
@@ -513,6 +517,7 @@ fn generate_uri_schemes(
 //! FILE GENERATED FROM REVISION {} OF THE BLUETOOTH SIG REPOSITORY, DO NOT EDIT!!!
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u16)]
 #[non_exhaustive]
 /// Assigned numbers for Bluetooth URI schemes defined in


### PR DESCRIPTION
Add `defmt::Format` derive support to multiple structs in the BLE stack, enhancing logging capabilities on embedded devices, that is enabled with the `defmt` feature. Remove the thiserror dependency.