### PR TITLE
chore: Update nom parser usage for numbers

### DIFF
--- a/bletio-hci/src/advertising/advertising_data.rs
+++ b/bletio-hci/src/advertising/advertising_data.rs
@@ -91,14 +91,14 @@ pub(crate) mod parser {
     use nom::{
         bytes::take,
         combinator::{all_consuming, map_res, verify},
-        number::le_u8,
+        number::complete::le_u8,
         IResult, Parser,
     };
 
     use super::*;
 
     fn advertising_data_length(input: &[u8]) -> IResult<&[u8], u8> {
-        verify(le_u8(), |v| (*v as usize) < ADVERTISING_DATA_TOTAL_SIZE).parse(input)
+        verify(le_u8, |v| (*v as usize) < ADVERTISING_DATA_TOTAL_SIZE).parse(input)
     }
 
     pub(crate) fn advertising_data(input: &[u8]) -> IResult<&[u8], AdvertisingData> {

--- a/bletio-hci/src/advertising/advertising_enable.rs
+++ b/bletio-hci/src/advertising/advertising_enable.rs
@@ -32,14 +32,14 @@ impl EncodeToBuffer for AdvertisingEnable {
 pub(crate) mod parser {
     use nom::{
         combinator::{all_consuming, map_res},
-        number::le_u8,
+        number::complete::le_u8,
         IResult, Parser,
     };
 
     use super::AdvertisingEnable;
 
     pub(crate) fn advertising_enable(input: &[u8]) -> IResult<&[u8], AdvertisingEnable> {
-        all_consuming(map_res(le_u8(), TryInto::try_into)).parse(input)
+        all_consuming(map_res(le_u8, TryInto::try_into)).parse(input)
     }
 }
 

--- a/bletio-hci/src/advertising/advertising_parameters.rs
+++ b/bletio-hci/src/advertising/advertising_parameters.rs
@@ -348,7 +348,7 @@ impl EncodeToBuffer for AdvertisingParameters {
 pub(crate) mod parser {
     use nom::{
         combinator::{all_consuming, map, map_res},
-        number::{le_u16, le_u8},
+        number::complete::{le_u16, le_u8},
         sequence::pair,
         IResult, Parser,
     };
@@ -358,7 +358,7 @@ pub(crate) mod parser {
     use crate::common::peer_address_type::parser::peer_address;
 
     fn advertising_interval(input: &[u8]) -> IResult<&[u8], AdvertisingInterval> {
-        map_res(le_u16(), TryInto::try_into).parse(input)
+        map_res(le_u16, TryInto::try_into).parse(input)
     }
 
     fn advertising_interval_range(input: &[u8]) -> IResult<&[u8], AdvertisingIntervalRange> {
@@ -370,15 +370,15 @@ pub(crate) mod parser {
     }
 
     fn advertising_type(input: &[u8]) -> IResult<&[u8], AdvertisingType> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     fn channel_map(input: &[u8]) -> IResult<&[u8], AdvertisingChannelMap> {
-        map(le_u8(), AdvertisingChannelMap::from_bits_truncate).parse(input)
+        map(le_u8, AdvertisingChannelMap::from_bits_truncate).parse(input)
     }
 
     fn filter_policy(input: &[u8]) -> IResult<&[u8], AdvertisingFilterPolicy> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn advertising_parameters(input: &[u8]) -> IResult<&[u8], AdvertisingParameters> {

--- a/bletio-hci/src/command.rs
+++ b/bletio-hci/src/command.rs
@@ -214,7 +214,9 @@ impl CommandPacket {
 }
 
 pub(crate) mod parser {
-    use nom::{bytes::take, combinator::map, number::le_u16, sequence::pair, IResult, Parser};
+    use nom::{
+        bytes::take, combinator::map, number::complete::le_u16, sequence::pair, IResult, Parser,
+    };
 
     use crate::advertising::{
         advertising_data::parser::advertising_data, advertising_enable::parser::advertising_enable,
@@ -233,7 +235,7 @@ pub(crate) mod parser {
     use crate::{Command, CommandOpCode, Packet};
 
     pub(crate) fn command_opcode(input: &[u8]) -> IResult<&[u8], CommandOpCode> {
-        map(le_u16(), CommandOpCode::from).parse(input)
+        map(le_u16, CommandOpCode::from).parse(input)
     }
 
     pub(crate) fn command(input: &[u8]) -> IResult<&[u8], Packet> {

--- a/bletio-hci/src/common/event_mask.rs
+++ b/bletio-hci/src/common/event_mask.rs
@@ -51,14 +51,14 @@ impl Default for EventMask {
 pub(crate) mod parser {
     use nom::{
         combinator::{all_consuming, map},
-        number::le_u64,
+        number::complete::le_u64,
         IResult, Parser,
     };
 
     use super::EventMask;
 
     pub(crate) fn event_mask(input: &[u8]) -> IResult<&[u8], EventMask> {
-        all_consuming(map(le_u64(), EventMask::from_bits_truncate)).parse(input)
+        all_consuming(map(le_u64, EventMask::from_bits_truncate)).parse(input)
     }
 }
 

--- a/bletio-hci/src/common/le_event_mask.rs
+++ b/bletio-hci/src/common/le_event_mask.rs
@@ -161,14 +161,14 @@ impl Default for LeEventMask {
 pub(crate) mod parser {
     use nom::{
         combinator::{all_consuming, map},
-        number::le_u64,
+        number::complete::le_u64,
         IResult, Parser,
     };
 
     use super::*;
 
     pub(crate) fn le_event_mask(input: &[u8]) -> IResult<&[u8], LeEventMask> {
-        all_consuming(map(le_u64(), LeEventMask::from_bits_truncate)).parse(input)
+        all_consuming(map(le_u64, LeEventMask::from_bits_truncate)).parse(input)
     }
 }
 

--- a/bletio-hci/src/common/le_filter_accept_list_address.rs
+++ b/bletio-hci/src/common/le_filter_accept_list_address.rs
@@ -91,7 +91,7 @@ pub(crate) mod parser {
     use nom::{
         bytes::take,
         combinator::{all_consuming, map, map_res},
-        number::le_u8,
+        number::complete::le_u8,
         IResult, Parser,
     };
 
@@ -102,7 +102,7 @@ pub(crate) mod parser {
     fn le_filter_accept_list_address_type(
         input: &[u8],
     ) -> IResult<&[u8], LeFilterAcceptListAddressType> {
-        map_res(le_u8(), TryFrom::try_from).parse(input)
+        map_res(le_u8, TryFrom::try_from).parse(input)
     }
 
     fn le_filter_accept_list_address_public(

--- a/bletio-hci/src/common/own_address_type.rs
+++ b/bletio-hci/src/common/own_address_type.rs
@@ -39,11 +39,11 @@ impl EncodeToBuffer for OwnAddressType {
 }
 
 pub(crate) mod parser {
-    use nom::{combinator::map_res, number::le_u8, IResult, Parser};
+    use nom::{combinator::map_res, number::complete::le_u8, IResult, Parser};
 
     use super::*;
 
     pub(crate) fn own_address_type(input: &[u8]) -> IResult<&[u8], OwnAddressType> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 }

--- a/bletio-hci/src/common/peer_address_type.rs
+++ b/bletio-hci/src/common/peer_address_type.rs
@@ -39,13 +39,13 @@ impl EncodeToBuffer for PeerAddressType {
 }
 
 pub(crate) mod parser {
-    use nom::{bytes::take, combinator::map_res, number::le_u8, IResult, Parser};
+    use nom::{bytes::take, combinator::map_res, number::complete::le_u8, IResult, Parser};
 
     use crate::common::peer_address_type::PeerAddressType;
     use crate::{DeviceAddress, Error, PublicDeviceAddress, RandomAddress};
 
     fn peer_address_type(input: &[u8]) -> IResult<&[u8], PeerAddressType> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn peer_address(input: &[u8]) -> IResult<&[u8], DeviceAddress> {

--- a/bletio-hci/src/connection/connection_parameters.rs
+++ b/bletio-hci/src/connection/connection_parameters.rs
@@ -272,7 +272,7 @@ pub(crate) mod parser {
     use nom::combinator::{all_consuming, map};
     use nom::{
         combinator::map_res,
-        number::{le_u16, le_u8},
+        number::complete::{le_u16, le_u8},
         IResult, Parser,
     };
 
@@ -286,19 +286,19 @@ pub(crate) mod parser {
     use super::*;
 
     fn initiator_filter_policy(input: &[u8]) -> IResult<&[u8], InitiatorFilterPolicy> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     fn max_latency(input: &[u8]) -> IResult<&[u8], Latency> {
-        map_res(le_u16(), TryInto::try_into).parse(input)
+        map_res(le_u16, TryInto::try_into).parse(input)
     }
 
     fn supervision_timeout(input: &[u8]) -> IResult<&[u8], SupervisionTimeout> {
-        map_res(le_u16(), TryInto::try_into).parse(input)
+        map_res(le_u16, TryInto::try_into).parse(input)
     }
 
     fn connection_event_length_range(input: &[u8]) -> IResult<&[u8], ConnectionEventLengthRange> {
-        map_res((le_u16(), le_u16()), |(start, end)| {
+        map_res((le_u16, le_u16), |(start, end)| {
             ConnectionEventLengthRange::try_new(start, end)
         })
         .parse(input)

--- a/bletio-hci/src/connection/connection_peer_address.rs
+++ b/bletio-hci/src/connection/connection_peer_address.rs
@@ -91,13 +91,13 @@ impl EncodeToBuffer for ConnectionPeerAddress {
 }
 
 pub(crate) mod parser {
-    use nom::{combinator::map_res, number::le_u8, IResult, Parser};
+    use nom::{combinator::map_res, number::complete::le_u8, IResult, Parser};
 
     use super::*;
     use crate::common::device_address::parser::address;
 
     fn connection_peer_address_type(input: &[u8]) -> IResult<&[u8], ConnectionPeerAddressType> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn connection_peer_address(input: &[u8]) -> IResult<&[u8], ConnectionPeerAddress> {

--- a/bletio-hci/src/event/command_complete.rs
+++ b/bletio-hci/src/event/command_complete.rs
@@ -174,7 +174,7 @@ pub(crate) mod parser {
     use nom::{
         bytes::take,
         combinator::{eof, map, map_res},
-        number::{le_i8, le_u16, le_u64, le_u8},
+        number::complete::{le_i8, le_u16, le_u64, le_u8},
         sequence::pair,
         IResult, Parser,
     };
@@ -192,7 +192,7 @@ pub(crate) mod parser {
     }
 
     fn supported_features(input: &[u8]) -> IResult<&[u8], SupportedFeatures> {
-        map(le_u64(), SupportedFeatures::from_bits_truncate).parse(input)
+        map(le_u64, SupportedFeatures::from_bits_truncate).parse(input)
     }
 
     fn bd_addr(input: &[u8]) -> IResult<&[u8], PublicDeviceAddress> {
@@ -205,16 +205,16 @@ pub(crate) mod parser {
 
     fn buffer_size(input: &[u8]) -> IResult<&[u8], (NonZeroU16, NonZeroU8, NonZeroU16, u16)> {
         (
-            map_res(le_u16(), TryInto::try_into),
-            map_res(le_u8(), TryInto::try_into),
-            map_res(le_u16(), TryInto::try_into),
-            le_u16(),
+            map_res(le_u16, TryInto::try_into),
+            map_res(le_u8, TryInto::try_into),
+            map_res(le_u16, TryInto::try_into),
+            le_u16,
         )
             .parse(input)
     }
 
     fn le_buffer_size(input: &[u8]) -> IResult<&[u8], (u16, u8)> {
-        (le_u16(), le_u8()).parse(input)
+        (le_u16, le_u8).parse(input)
     }
 
     fn le_supported_features_page_0(input: &[u8]) -> IResult<&[u8], SupportedLeFeatures> {
@@ -222,11 +222,11 @@ pub(crate) mod parser {
     }
 
     fn le_supported_states(input: &[u8]) -> IResult<&[u8], SupportedLeStates> {
-        map(le_u64(), Into::into).parse(input)
+        map(le_u64, Into::into).parse(input)
     }
 
     fn tx_power_level(input: &[u8]) -> IResult<&[u8], TxPowerLevel> {
-        map_res(le_i8(), TryInto::try_into).parse(input)
+        map_res(le_i8, TryInto::try_into).parse(input)
     }
 
     fn random_number(input: &[u8]) -> IResult<&[u8], [u8; 8]> {
@@ -234,7 +234,7 @@ pub(crate) mod parser {
     }
 
     fn filter_accept_list_size(input: &[u8]) -> IResult<&[u8], usize> {
-        map(le_u8(), |v| v as usize).parse(input)
+        map(le_u8, |v| v as usize).parse(input)
     }
 
     pub(crate) fn command_complete_event(input: &[u8]) -> IResult<&[u8], CommandCompleteEvent> {

--- a/bletio-hci/src/event/le_advertising_report.rs
+++ b/bletio-hci/src/event/le_advertising_report.rs
@@ -170,7 +170,7 @@ pub(crate) mod parser {
     use nom::{
         bytes::take,
         combinator::{consumed, eof, map, map_res},
-        number::le_u8,
+        number::complete::le_u8,
         IResult, Parser,
     };
 
@@ -181,17 +181,17 @@ pub(crate) mod parser {
     fn le_advertising_report_num_reports(
         input: &[u8],
     ) -> IResult<&[u8], LeAdvertisingReportNumReports> {
-        map_res(le_u8(), LeAdvertisingReportNumReports::try_from).parse(input)
+        map_res(le_u8, LeAdvertisingReportNumReports::try_from).parse(input)
     }
 
     fn le_advertising_report_event_type(
         input: &[u8],
     ) -> IResult<&[u8], LeAdvertisingReportEventType> {
-        map_res(le_u8(), LeAdvertisingReportEventType::try_from).parse(input)
+        map_res(le_u8, LeAdvertisingReportEventType::try_from).parse(input)
     }
 
     fn le_advertising_report_data_length(input: &[u8]) -> IResult<&[u8], u8> {
-        le_u8().parse(input)
+        le_u8.parse(input)
     }
 
     fn le_advertising_report_data(input: &[u8]) -> IResult<&[u8], LeAdvertisingReportData> {
@@ -200,7 +200,7 @@ pub(crate) mod parser {
     }
 
     fn le_advertising_report_rssi(input: &[u8]) -> IResult<&[u8], Option<Rssi>> {
-        map_res(le_u8(), |v| match v {
+        map_res(le_u8, |v| match v {
             0x7F => Ok::<_, Error>(None),
             _ => Ok(Some(Rssi::try_new(v as i8)?)),
         })

--- a/bletio-hci/src/event/le_meta.rs
+++ b/bletio-hci/src/event/le_meta.rs
@@ -22,14 +22,14 @@ enum LeMetaEventCode {
 }
 
 pub(crate) mod parser {
-    use nom::{combinator::map_res, number::le_u8, IResult, Parser};
+    use nom::{combinator::map_res, number::complete::le_u8, IResult, Parser};
 
     use super::*;
     use crate::event::le_advertising_report::parser::le_advertising_report_event;
     use crate::event::le_connection_complete::parser::le_connection_complete_event;
 
     fn le_meta_event_code(input: &[u8]) -> IResult<&[u8], LeMetaEventCode> {
-        map_res(le_u8(), LeMetaEventCode::try_from).parse(input)
+        map_res(le_u8, LeMetaEventCode::try_from).parse(input)
     }
 
     pub(crate) fn le_meta_event(input: &[u8]) -> IResult<&[u8], LeMetaEvent> {

--- a/bletio-hci/src/event/mod.rs
+++ b/bletio-hci/src/event/mod.rs
@@ -56,7 +56,9 @@ enum EventCode {
 }
 
 pub(crate) mod parser {
-    use nom::{bytes::take, combinator::map_res, number::le_u8, sequence::pair, IResult, Parser};
+    use nom::{
+        bytes::take, combinator::map_res, number::complete::le_u8, sequence::pair, IResult, Parser,
+    };
 
     use super::*;
     use crate::event::command_status::parser::command_status_event;
@@ -70,15 +72,15 @@ pub(crate) mod parser {
     };
 
     fn event_code(input: &[u8]) -> IResult<&[u8], EventCode> {
-        map_res(le_u8(), EventCode::try_from).parse(input)
+        map_res(le_u8, EventCode::try_from).parse(input)
     }
 
     pub(crate) fn num_hci_command_packets(input: &[u8]) -> IResult<&[u8], u8> {
-        le_u8().parse(input)
+        le_u8.parse(input)
     }
 
     pub(crate) fn hci_error_code(input: &[u8]) -> IResult<&[u8], ErrorCode> {
-        map_res(le_u8(), ErrorCode::try_from).parse(input)
+        map_res(le_u8, ErrorCode::try_from).parse(input)
     }
 
     pub(crate) fn event(input: &[u8]) -> IResult<&[u8], Packet> {

--- a/bletio-hci/src/packet.rs
+++ b/bletio-hci/src/packet.rs
@@ -32,7 +32,7 @@ pub(crate) enum Packet {
 }
 
 pub(crate) mod parser {
-    use nom::{combinator::map_res, number::le_u8, IResult, Parser};
+    use nom::{combinator::map_res, number::complete::le_u8, IResult, Parser};
 
     use crate::{
         acl_data::parser::acl_data, command::parser::command, event::parser::event, Packet,
@@ -40,11 +40,11 @@ pub(crate) mod parser {
     };
 
     pub(crate) fn parameter_total_length(input: &[u8]) -> IResult<&[u8], u8> {
-        le_u8().parse(input)
+        le_u8.parse(input)
     }
 
     pub(crate) fn packet(input: &[u8]) -> IResult<&[u8], Packet> {
-        let (input, packet_type) = map_res(le_u8(), PacketType::try_from).parse(input)?;
+        let (input, packet_type) = map_res(le_u8, PacketType::try_from).parse(input)?;
         match packet_type {
             PacketType::Command => command.parse(input),
             PacketType::AclData => acl_data.parse(input),

--- a/bletio-hci/src/scanning/scan_enable.rs
+++ b/bletio-hci/src/scanning/scan_enable.rs
@@ -58,18 +58,18 @@ impl EncodeToBuffer for FilterDuplicates {
 pub(crate) mod parser {
     use nom::{
         combinator::{all_consuming, map_res},
-        number::le_u8,
+        number::complete::le_u8,
         IResult, Parser,
     };
 
     use super::{FilterDuplicates, ScanEnable};
 
     fn scan_enable(input: &[u8]) -> IResult<&[u8], ScanEnable> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     fn filter_duplicates(input: &[u8]) -> IResult<&[u8], FilterDuplicates> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn scan_enable_parameters(

--- a/bletio-hci/src/scanning/scan_interval.rs
+++ b/bletio-hci/src/scanning/scan_interval.rs
@@ -101,12 +101,12 @@ macro_rules! __scan_interval__ {
 pub use __scan_interval__ as scan_interval;
 
 pub(crate) mod parser {
-    use nom::{combinator::map_res, number::le_u16, IResult, Parser};
+    use nom::{combinator::map_res, number::complete::le_u16, IResult, Parser};
 
     use super::*;
 
     pub(crate) fn scan_interval(input: &[u8]) -> IResult<&[u8], ScanInterval> {
-        map_res(le_u16(), TryInto::try_into).parse(input)
+        map_res(le_u16, TryInto::try_into).parse(input)
     }
 }
 

--- a/bletio-hci/src/scanning/scan_parameters.rs
+++ b/bletio-hci/src/scanning/scan_parameters.rs
@@ -147,7 +147,7 @@ impl EncodeToBuffer for ScanParameters {
 pub(crate) mod parser {
     use nom::{
         combinator::{all_consuming, map_res},
-        number::le_u8,
+        number::complete::le_u8,
         IResult, Parser,
     };
 
@@ -157,11 +157,11 @@ pub(crate) mod parser {
     use super::*;
 
     fn scan_type(input: &[u8]) -> IResult<&[u8], ScanType> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     fn filter_policy(input: &[u8]) -> IResult<&[u8], ScanningFilterPolicy> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn scan_parameters(input: &[u8]) -> IResult<&[u8], ScanParameters> {

--- a/bletio-hci/src/scanning/scan_window.rs
+++ b/bletio-hci/src/scanning/scan_window.rs
@@ -101,12 +101,12 @@ macro_rules! __scan_window__ {
 pub use __scan_window__ as scan_window;
 
 pub(crate) mod parser {
-    use nom::{combinator::map_res, number::le_u16, IResult, Parser};
+    use nom::{combinator::map_res, number::complete::le_u16, IResult, Parser};
 
     use super::*;
 
     pub(crate) fn scan_window(input: &[u8]) -> IResult<&[u8], ScanWindow> {
-        map_res(le_u16(), TryInto::try_into).parse(input)
+        map_res(le_u16, TryInto::try_into).parse(input)
     }
 }
 

--- a/bletio-host/src/advertising/ad_struct/advertising_interval.rs
+++ b/bletio-host/src/advertising/ad_struct/advertising_interval.rs
@@ -46,7 +46,7 @@ impl EncodeToBuffer for AdvertisingIntervalAdStruct {
 pub(crate) mod parser {
     use nom::{
         combinator::{map, map_res},
-        number::le_u16,
+        number::complete::le_u16,
         IResult, Parser,
     };
 
@@ -55,7 +55,7 @@ pub(crate) mod parser {
     use super::*;
 
     pub(crate) fn advertising_interval_ad_struct(input: &[u8]) -> IResult<&[u8], AdStruct> {
-        map(map_res(le_u16(), TryInto::try_into), |interval| {
+        map(map_res(le_u16, TryInto::try_into), |interval| {
             AdStruct::AdvertisingInterval(AdvertisingIntervalAdStruct::new(interval))
         })
         .parse(input)

--- a/bletio-host/src/advertising/ad_struct/appearance.rs
+++ b/bletio-host/src/advertising/ad_struct/appearance.rs
@@ -45,7 +45,7 @@ impl EncodeToBuffer for AppearanceAdStruct {
 pub(crate) mod parser {
     use nom::{
         combinator::{map, map_res},
-        number::le_u16,
+        number::complete::le_u16,
         IResult, Parser,
     };
 
@@ -54,7 +54,7 @@ pub(crate) mod parser {
     use super::*;
 
     pub(crate) fn appearance_ad_struct(input: &[u8]) -> IResult<&[u8], AdStruct> {
-        map(map_res(le_u16(), TryFrom::try_from), |appearance| {
+        map(map_res(le_u16, TryFrom::try_from), |appearance| {
             AdStruct::Appearance(AppearanceAdStruct::new(appearance))
         })
         .parse(input)

--- a/bletio-host/src/advertising/ad_struct/flags.rs
+++ b/bletio-host/src/advertising/ad_struct/flags.rs
@@ -78,14 +78,14 @@ impl From<u8> for Flags {
 }
 
 pub(crate) mod parser {
-    use nom::{combinator::map, number::le_u8, IResult, Parser};
+    use nom::{combinator::map, number::complete::le_u8, IResult, Parser};
 
     use crate::advertising::ad_struct::AdStruct;
 
     use super::*;
 
     pub(crate) fn flags_ad_struct(input: &[u8]) -> IResult<&[u8], AdStruct> {
-        map(le_u8(), |v| AdStruct::Flags(FlagsAdStruct::new(v.into()))).parse(input)
+        map(le_u8, |v| AdStruct::Flags(FlagsAdStruct::new(v.into()))).parse(input)
     }
 }
 

--- a/bletio-host/src/advertising/ad_struct/manufacturer_specific_data.rs
+++ b/bletio-host/src/advertising/ad_struct/manufacturer_specific_data.rs
@@ -64,7 +64,7 @@ pub(crate) mod parser {
     use nom::{
         bytes::take,
         combinator::{fail, map_res},
-        number::le_u16,
+        number::complete::le_u16,
         IResult, Parser,
     };
 
@@ -73,7 +73,7 @@ pub(crate) mod parser {
     use super::*;
 
     fn company_identifier(input: &[u8]) -> IResult<&[u8], CompanyIdentifier> {
-        map_res(le_u16(), TryFrom::try_from).parse(input)
+        map_res(le_u16, TryFrom::try_from).parse(input)
     }
 
     pub(crate) fn manufacturer_specific_data_ad_struct(input: &[u8]) -> IResult<&[u8], AdStruct> {

--- a/bletio-host/src/advertising/ad_struct/peripheral_connection_interval_range.rs
+++ b/bletio-host/src/advertising/ad_struct/peripheral_connection_interval_range.rs
@@ -257,14 +257,14 @@ pub(crate) mod parser {
     use crate::advertising::ad_struct::AdStruct;
     use nom::{
         combinator::{map, map_res},
-        number::le_u16,
+        number::complete::le_u16,
         IResult, Parser,
     };
 
     fn peripheral_connection_interval_range(
         input: &[u8],
     ) -> IResult<&[u8], PeripheralConnectionIntervalRange> {
-        map_res((le_u16(), le_u16()), |(start, end)| {
+        map_res((le_u16, le_u16), |(start, end)| {
             PeripheralConnectionIntervalRange::try_new(start, end)
         })
         .parse(input)

--- a/bletio-host/src/advertising/ad_struct/tx_power_level.rs
+++ b/bletio-host/src/advertising/ad_struct/tx_power_level.rs
@@ -47,7 +47,7 @@ pub(crate) mod parser {
     use bletio_hci::TxPowerLevel;
     use nom::{
         combinator::{map, map_res},
-        number::le_i8,
+        number::complete::le_i8,
         IResult, Parser,
     };
 
@@ -56,7 +56,7 @@ pub(crate) mod parser {
     use super::*;
 
     fn tx_power_level(input: &[u8]) -> IResult<&[u8], TxPowerLevel> {
-        map_res(le_i8(), TryInto::try_into).parse(input)
+        map_res(le_i8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn tx_power_level_ad_struct(input: &[u8]) -> IResult<&[u8], AdStruct> {

--- a/bletio-host/src/advertising/advertising_data.rs
+++ b/bletio-host/src/advertising/advertising_data.rs
@@ -566,7 +566,7 @@ impl FullAdvertisingData {
 pub(crate) mod parser {
     use nom::{
         combinator::{map, map_res},
-        number::{le_u128, le_u16, le_u32, le_u8},
+        number::complete::{le_u128, le_u16, le_u32, le_u8},
         IResult, Parser,
     };
 
@@ -607,27 +607,27 @@ pub(crate) mod parser {
     };
 
     pub(crate) fn advertising_data_length(input: &[u8]) -> IResult<&[u8], u8> {
-        le_u8().parse(input)
+        le_u8.parse(input)
     }
 
     pub(crate) fn ad_struct_length(input: &[u8]) -> IResult<&[u8], usize> {
-        map(le_u8(), |v| v as usize).parse(input)
+        map(le_u8, |v| v as usize).parse(input)
     }
 
     fn ad_type(input: &[u8]) -> IResult<&[u8], AdType> {
-        map_res(le_u8(), TryInto::try_into).parse(input)
+        map_res(le_u8, TryInto::try_into).parse(input)
     }
 
     pub(crate) fn service_uuid(input: &[u8]) -> IResult<&[u8], ServiceUuid> {
-        map_res(le_u16(), TryFrom::try_from).parse(input)
+        map_res(le_u16, TryFrom::try_from).parse(input)
     }
 
     pub(crate) fn uuid32(input: &[u8]) -> IResult<&[u8], Uuid32> {
-        map(le_u32(), Into::into).parse(input)
+        map(le_u32, Into::into).parse(input)
     }
 
     pub(crate) fn uuid128(input: &[u8]) -> IResult<&[u8], Uuid128> {
-        map(le_u128(), Into::into).parse(input)
+        map(le_u128, Into::into).parse(input)
     }
 
     pub(crate) fn ad_struct(input: &[u8]) -> IResult<&[u8], (usize, AdStruct)> {

--- a/bletio-host/src/advertising/uri.rs
+++ b/bletio-host/src/advertising/uri.rs
@@ -313,7 +313,7 @@ pub(crate) mod parser {
         branch::alt,
         bytes::{tag, take, take_till1},
         combinator::{map, map_res, verify},
-        number::le_u16,
+        number::complete::le_u16,
         IResult, Parser,
     };
 
@@ -323,7 +323,7 @@ pub(crate) mod parser {
         map(
             map_res(
                 (
-                    verify(le_u16(), |value| *value == EMPTY_SCHEME_NAME_VALUE),
+                    verify(le_u16, |value| *value == EMPTY_SCHEME_NAME_VALUE),
                     map_res(take_till1(|b| b == b':'), core::str::from_utf8),
                     tag([b':'].as_slice()),
                 ),
@@ -336,7 +336,7 @@ pub(crate) mod parser {
 
     fn provisioned_uri_scheme(input: &[u8]) -> IResult<&[u8], UriScheme> {
         map(
-            map_res(le_u16(), TryFrom::try_from),
+            map_res(le_u16, TryFrom::try_from),
             |scheme: ProvisionedUriScheme| scheme.into(),
         )
         .parse(input)


### PR DESCRIPTION
Refactor the parser implementations across multiple files to use the complete variants of the `nom` library's number parsers.